### PR TITLE
customise.sh: fix oos12 detection

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -97,7 +97,7 @@ tar -xf $MODPATH/files/system.tar.xz -C $MODPATH
 
 chmod 0755 $MODPATH/addon/*
 
-if [ !-z "$(getprop ro.oplus.image.system.version)" ] && [ $NEW_API -ge 31 ]; then
+if [ -n "$(getprop ro.oplus.image.system.version)" ] && [ $API -ge 31 ]; then
     TARGET_DEVICE_OP12=1
 fi
 


### PR DESCRIPTION
!-z threw an unexpected operand error and replacing it with -n and using API Instead of NewAPI detects if device is running oos 12 properly